### PR TITLE
fix(preprocessing): handle NaNs in prestimulus mean calculation

### DIFF
--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -245,8 +245,9 @@ def run_AM_process(envs, pre_stim=2000):
             - feature_names (np.array): Names of extracted features
             - inds (list): List of (taste, trial) index tuples
     """
+
     this_day_prestim_dat = envs[..., :pre_stim]
-    mean_prestim = np.mean(this_day_prestim_dat, axis=None)
+    mean_prestim = np.nanmean(this_day_prestim_dat, axis=None)
 
     segment_dat_list = []
     inds = list(np.ndindex(envs.shape[:-1]))

--- a/src/visualize.py
+++ b/src/visualize.py
@@ -252,6 +252,7 @@ def plot_env_pred_overlay(
         segments_frame,
         raw_emg,
         cmap = None,
+        mad_scale = 5,
         ):
     """
     Create a comprehensive grid plot showing raw EMG signals with overlaid predictions.
@@ -276,6 +277,7 @@ def plot_env_pred_overlay(
                                                      - Orange (#EF8636): Gape
                                                      - Blue (#3B75AF): MTMs
                                                      Defaults to None.
+        mad_scale (float, optional): Scaling factor for median absolute deviation
 
     Returns:
         tuple: Contains two elements:
@@ -307,14 +309,18 @@ def plot_env_pred_overlay(
             figsize=(10, 10),
             sharex=True, sharey=True,
             )
+    median_value = np.median(raw_emg[~np.isnan(raw_emg)])
+    mad_value = median_abs_deviation(raw_emg[~np.isnan(raw_emg)])
+    y_lims = (-median_value, median_value + mad_scale * mad_value)
     for taste in range(raw_emg.shape[0]):
         for trial in trange(raw_emg.shape[1]):
             this_ax = ax[trial, taste]
             this_emg = raw_emg[taste, trial, :]
+            if this_emg is None or np.all(np.isnan(this_emg)):
+                continue
             this_ax.plot(this_emg, 'k-', linewidth=0.8)
             # Set y-limits based on median absolute deviation
-            this_emg_mad = median_abs_deviation(this_emg)
-            this_ax.set_ylim(-5 * this_emg_mad, 5 * this_emg_mad)
+            this_ax.set_ylim(y_lims)
             if taste == 0:
                 this_ax.set_ylabel(f'Trial\n{trial}')
             if trial == raw_emg.shape[1] - 1:


### PR DESCRIPTION
- Replace `np.mean` with `np.nanmean` to correctly calculate the mean by ignoring NaN values.
- This change ensures that NaN values do not affect the computation of `mean_prestim`.